### PR TITLE
Update pypi_publish.yml to only run on main branch

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -3,7 +3,10 @@ name: Publish package to PyPI and TestPyPI
 # Based on example given here:
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-on: push
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Update workflow `Publish package to PyPI and TestPyPI` to only run only on push to main branch.