### PR TITLE
Change to automatic versioning based on git tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [build-system]
-requires = ["hatchling >= 1.26"]
+requires = [
+    "hatchling >= 1.26",
+    "versioningit",
+]
 build-backend = "hatchling.build"
 
 [project]
 name = "pyrbd"
-version = "0.3.2"
 description = "Package for creating simple reliability block diagrams (RBDs) using LaTeX and TikZ."
 readme = "README.md"
 authors = [
@@ -20,6 +22,7 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python :: 3"
 ]
+dynamic = ["version"]
 
 [project.urls]
 Repository = "https://github.com/hghugdal/pyrbd"
@@ -69,6 +72,10 @@ dev = [
     "pytest>=8.4.1",
     "ruff>=0.12.8",
     "ty>=0.0.1a18",
+    "versioningit>=3.3.0",
 ]
 
-[tool.pylint]
+[tool.hatch.version]
+source = "versioningit"
+
+[tool.versioningit]

--- a/uv.lock
+++ b/uv.lock
@@ -781,7 +781,6 @@ wheels = [
 
 [[package]]
 name = "pyrbd"
-version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "pre-commit" },
@@ -802,6 +801,7 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
+    { name = "versioningit" },
 ]
 
 [package.metadata]
@@ -824,6 +824,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.8" },
     { name = "ty", specifier = ">=0.0.1a18" },
+    { name = "versioningit", specifier = ">=3.3.0" },
 ]
 
 [[package]]
@@ -1051,6 +1052,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "versioningit"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/f4/bc578cc80989c572231a36cc03cc097091176fa3fb8b4e2af1deb4370eb7/versioningit-3.3.0.tar.gz", hash = "sha256:b91ad7d73e73d21220e69540f20213f2b729a1f9b35c04e9e137eaf28d2214da", size = 220280, upload-time = "2025-06-27T20:13:23.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/59/964ecb8008722d27d8a835baea81f56a91cea8e097b3be992bc6ccde6367/versioningit-3.3.0-py3-none-any.whl", hash = "sha256:23b1db3c4756cded9bd6b0ddec6643c261e3d0c471707da3e0b230b81ce53e4b", size = 38439, upload-time = "2025-06-27T20:13:21.927Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Automatic build versioning of builds based on git tag using [versioningit](https://pypi.org/project/versioningit/) rather than manually updating version number in pyproject.toml..